### PR TITLE
Remove google-chrome from php image.

### DIFF
--- a/services/php-apache/Dockerfile
+++ b/services/php-apache/Dockerfile
@@ -10,8 +10,6 @@ RUN curl -sL https://deb.nodesource.com/setup_10.x | bash - \
     && echo "deb http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google.list \
     && apt-get update \
     && apt-get --quiet install -y --no-install-recommends \
-      google-chrome-stable \
-      libxss1 \
       nodejs \
       parallel \
       python3-pip \


### PR DESCRIPTION
## Description
Remove google-chrome from php image.

## Motivation / Context
Created [image specifically for google-chrome](https://github.com/ChromaticHQ/docker-images/blob/main/services/google-chrome/Dockerfile).

## Testing Instructions / How This Has Been Tested
CI should build successfully.