### PR TITLE
Add libxtst6 to node image

### DIFF
--- a/services/node/Dockerfile
+++ b/services/node/Dockerfile
@@ -6,6 +6,7 @@ RUN curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add - \
     && apt-get update \
     && apt-get --quiet install -y --no-install-recommends \
       libxss1 \
+      libxtst6 \
       google-chrome-stable \
       nodejs \
       yarn \


### PR DESCRIPTION
## Description
This PR installs the `libxtst6` library in the `node` image.

## Motivation / Context
Our `integration-tests` service in `benz-platform` started failing
with Puppeteer throwing an exception about this missing library.

## Testing Instructions / How This Has Been Tested
I have validated this change by installing `libxtst6` manually on a Tugboat preview’s `integration-tests` service and re-running tests. I then created ChromaticHQ/benz-platform#2672 to install `libxtst6` in the `init` step and built a preview for it from scratch. That preview built successfully and tests passed. It was merged to `master` to unblock the PRs, but it should be followed up with a PR that removes that installation step after this PR is merged and an updated `chromatic/node` image is available.

## Screenshots
N/A

## Documentation
N/A
