### PR TITLE
Use nvm to install Node.js

### DIFF
--- a/services/php-apache/Dockerfile
+++ b/services/php-apache/Dockerfile
@@ -5,6 +5,7 @@ ENV COMPOSER_NO_INTERACTION=true
 ENV COMPOSER_ALLOW_SUPERUSER=true
 RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.38.0/install.sh | bash - \
     && source ~/.bashrc \
+    && nvm install lts \
     && nvm install 10 \
     && nvm use 10 \
     && curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add - \

--- a/services/php-apache/Dockerfile
+++ b/services/php-apache/Dockerfile
@@ -16,7 +16,6 @@ RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.38.0/install.sh | b
     && apt-get update \
     && apt-get --quiet install -y --no-install-recommends \
       libzip-dev \
-      nodejs \
       parallel \
       python3-pip \
       redis-tools \

--- a/services/php-apache/Dockerfile
+++ b/services/php-apache/Dockerfile
@@ -3,7 +3,10 @@ FROM tugboatqa/php:${PHP_VERSION}-apache
 ENV COMPOSER_DISCARD_CHANGES=true
 ENV COMPOSER_NO_INTERACTION=true
 ENV COMPOSER_ALLOW_SUPERUSER=true
-RUN curl -sL https://deb.nodesource.com/setup_10.x | bash - \
+RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.38.0/install.sh | bash - \
+    && source ~/.bashrc \
+    && nvm install 10 \
+    && nvm use 10 \
     && curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add - \
     && echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list \
     && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \

--- a/services/php-apache/Dockerfile
+++ b/services/php-apache/Dockerfile
@@ -4,7 +4,7 @@ ENV COMPOSER_DISCARD_CHANGES=true
 ENV COMPOSER_NO_INTERACTION=true
 ENV COMPOSER_ALLOW_SUPERUSER=true
 RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.38.0/install.sh | bash - \
-    && source ~/.bashrc \
+    && . ~/.bashrc \
     && nvm install lts \
     && nvm install 10 \
     && nvm use 10 \

--- a/services/php-apache/Dockerfile
+++ b/services/php-apache/Dockerfile
@@ -8,6 +8,7 @@ RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.38.0/install.sh | b
     && nvm install lts \
     && nvm install 10 \
     && nvm use 10 \
+    && nvm alias default 10 \
     && curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add - \
     && echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list \
     && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \

--- a/services/php-apache/Dockerfile
+++ b/services/php-apache/Dockerfile
@@ -5,7 +5,7 @@ ENV COMPOSER_NO_INTERACTION=true
 ENV COMPOSER_ALLOW_SUPERUSER=true
 RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.38.0/install.sh | bash - \
     && . ~/.bashrc \
-    && nvm install lts \
+    && nvm install --lts \
     && nvm install 10 \
     && nvm use 10 \
     && nvm alias default 10 \


### PR DESCRIPTION
## Description

This PR replaces our current strategy, where we install Node.js v10 directly, with an nvm-based solution, where we first install nvm and then use nvm to install v10. We also install the latest LTS version of Node.

## Motivation / Context

The intent here is to make nvm available to all consumers of our `php-apache` images so that individual projects can track their required version of Node.js in an `.nvmrc` file and use the nvm command to install said version.

In addition to that goal, this PR also preemptively installs Node v10 and the LTS version:
- v10 is installed and made the default version of Node in an effort to stay backwards compatible with projects that currently rely on v10 already being installed on this image. The idea is to eventually move all of our projects to either use LTS by default or declare and install their own version of Node via nvm, so the lines that install, use, and set v10 as the default will be removed eventually.
- LTS is installed so that projects using the latest version of Node get the benefit of already having LTS installed and thus running `nvm install && nvm use` in those projects will exit relatively quickly. This should help shorten build times in environments that are built from scratch (production, Tugboat base previews, Lando containers, etc).

## Testing Instructions / How This Has Been Tested

@markdorison I’ll need your assistance testing this to ensure it doesn’t break things on projects relying on Node.js v10 and that nvm is indeed installed and working correctly on projects moving to that strategy.

## Screenshots

n/a

## Documentation

- Should we document our Node.js installation strategy in the README?