### PR TITLE
Revert "Use nvm to install Node.js"

### DIFF
--- a/services/php-apache/Dockerfile
+++ b/services/php-apache/Dockerfile
@@ -3,12 +3,7 @@ FROM tugboatqa/php:${PHP_VERSION}-apache
 ENV COMPOSER_DISCARD_CHANGES=true
 ENV COMPOSER_NO_INTERACTION=true
 ENV COMPOSER_ALLOW_SUPERUSER=true
-RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.38.0/install.sh | bash - \
-    && . ~/.bashrc \
-    && nvm install --lts \
-    && nvm install 10 \
-    && nvm use 10 \
-    && nvm alias default 10 \
+RUN curl -sL https://deb.nodesource.com/setup_10.x | bash - \
     && curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add - \
     && echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list \
     && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
@@ -16,6 +11,7 @@ RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.38.0/install.sh | b
     && apt-get update \
     && apt-get --quiet install -y --no-install-recommends \
       libzip-dev \
+      nodejs \
       parallel \
       python3-pip \
       redis-tools \


### PR DESCRIPTION
Reverts ChromaticHQ/docker-images#12

## Motivation

As can be seen in [these logs](https://dashboard.tugboat.qa/log/6152041dcc9cc444f557af1b) for [this failed `benz-platform` preview](https://dashboard.tugboat.qa/6152041c4807c07ab33c93e2), the previews cannot seem to find Node.js when building a theme:

```
2021-09-27T17:53:18.865Z - 6152041dcc9cc444f557af1b# /bin/sh -c $TUGBOAT_ROOT/vendor/bin/robo tugboat:build-benz-platform

build sites on tugboat.
=======================

build benzy base theme assets.
------------------------------

 [Exec] Running yarn benzy-build in web/themes/custom/benzy/
Yarn requires Node.js 4.0 or higher to be installed.
```