### PR TITLE
Remove Tugboat git configuration from images.

### DIFF
--- a/services/php-apache-nvm/Dockerfile
+++ b/services/php-apache-nvm/Dockerfile
@@ -33,4 +33,6 @@ RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.0/install.sh | b
     && docker-php-ext-install zip \
     && a2enmod headers rewrite \
     && apt-get clean \
-    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
+    && git config --global --unset user.name  \
+    && git config --global --unset user.email

--- a/services/php-apache/Dockerfile
+++ b/services/php-apache/Dockerfile
@@ -29,4 +29,6 @@ RUN curl -sL https://deb.nodesource.com/setup_10.x | bash - \
     && docker-php-ext-install zip \
     && a2enmod headers rewrite \
     && apt-get clean \
-    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
+    && git config --global --unset user.name  \
+    && git config --global --unset user.email


### PR DESCRIPTION
## Description
Removes the tugboat git configuration for user and email.

## Motivation / Context
The `tugboatqa/php` images include git config for a Tugboat user and email.  This causes conflicts when using [codespaces](https://github.com/ChromaticHQ/chromatichq.com/pull/3472) and pushing commits from the Codespaces terminal. 

## Testing Instructions / How This Has Been Tested

Build images locally and compared the `git config --list` outputs:

Current PHP Images
```
docker exec -it 19038c0fb3c71cdeb1f94ed93a33df7bba1e4d0f648054b81208d4172b919bf7 /bin/sh
# git config --list
user.email=root@tugboat.qa
user.name=Tugboat
```

This PR
```
docker exec -it a4394268d75c81f17a48068a866f7ace87254e4b0fda6944fbb0739f804194a7 /bin/sh
# git config --list
# 

```

## Screenshots
![Screen Shot 2021-10-27 at 3 42 24 PM](https://user-images.githubusercontent.com/744601/139143930-08373f01-f385-47b8-b9e0-6c09c5d3003b.png)



## Documentation
N/A
