### PR TITLE
Set nvm’s “default” alias to installed version

### DIFF
--- a/services/php-apache-nvm/Dockerfile
+++ b/services/php-apache-nvm/Dockerfile
@@ -9,7 +9,7 @@ RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.0/install.sh | b
     && nvm install --lts \
     && echo "#!/bin/bash -l" > $INSTALL_NODE_SCRIPT_PATH \
     && echo "set -e" >> $INSTALL_NODE_SCRIPT_PATH \
-    && echo "nvm install" >> $INSTALL_NODE_SCRIPT_PATH \
+    && echo "nvm install --default" >> $INSTALL_NODE_SCRIPT_PATH \
     && echo "npm install -g yarn" >> $INSTALL_NODE_SCRIPT_PATH \
     && chmod +x $INSTALL_NODE_SCRIPT_PATH \
     && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \


### PR DESCRIPTION
## Description

This PR updates the `/usr/local/bin/install-node-yarn-via-nvm` script available in our `php-apache-nvm` service to set the newly-installed version of Node as the default version of Node.

## Motivation / Context

After getting reports that CHQ’s Base Preview was failing to build with errors that appear to indicate that Node (and Node-related tools, such as Yarn) cannot be found, I did some digging and found that Tugboat previews are stuck in a sort of limbo at the moment. The issue is best explained as a list of conditions, all of which —together— form a perfect storm of 💩:

- When nvm is used for the very first time to install Node in any system, it sets the `default` alias to the version installed at that moment. In our case, whatever version of Node is marked as `Active LTS` in Node’s repository is installed. So nvm’s aliases look like so: `default -> lts/* (-> v14.18.1 *)`, as can be seen in [this line of the most recent build](https://github.com/ChromaticHQ/docker-images/runs/3968784174?check_suite_focus=true#step:5:181). It is very important to note that `default` does not point directly to `v14.18.1`; it points to `lts/*` because the version of Node we install by default is `lts`. So the `default` alias points to the `lts/*` alias, which in turn points to the `v14.18.1` version that was just installed.
- When I check the aliases in the Tugboat terminal, I see the following:
    ```
    root@node:/var/lib/tugboat# nvm alias
    default -> lts/* (-> N/A)
    … (some other aliases) …
    lts/* -> lts/gallium (-> N/A)
    … (even more aliases) …
    lts/fermium -> v14.18.1
    lts/gallium -> v16.13.0 (-> N/A)
    ```
    🤔 Note how now we have `default -> lts/* (-> N/A)` instead of `default -> lts/* (-> v14.18.1)`. Also note how `lts/*` points to `lts/gallium`, which in turn points to `v16.13.0`. I triple-checked my math and I’m pretty confident 16 ≠ 14.
- Here’s what [nvm’s documentation about LTS](https://github.com/nvm-sh/nvm#long-term-support) has to say about those `lts/…` aliases…
    >Any time your local copy of `nvm` connects to [nodejs.org](https://nodejs.org/), it will re-create the appropriate local aliases for all available LTS lines.
- Looking at the [NodeJS.org Releases page](https://nodejs.org/en/about/releases/), it looks like v16 of Node was given `Active LTS` status yesterday.

So what we have right now in Tugboat is an image built last week, with a `default` nvm alias that —when last built— resolved to v14, which is installed and available. However, in the context of a new Tugboat build, nvm connects to nodejs.org, meaning it has had a chance to “re-create the appropriate local aliases for all available LTS lines”, which —as of sometime yesterday— means that the `lts/*` alias points to a version of Node that is not installed in that image, and because the `default` alias points to `lts/*` then it’s as if Node doesn’t even exist in the system at all.

The solution is to add the `--default` flag to the `nvm install` command in the `/usr/local/bin/install-node-yarn-via-nvm` script we generate during docker image creation. That makes it so that when our Tugboat commands invoke that script, nvm will be told to set whatever version it just detected in the `.nvmrc` file as the `default`. That results in an alias that looks like this: `default -> 14 (-> v14.18.1)`, which is what we want.

## Testing Instructions / How This Has Been Tested

If Docker image validation passes (as I expect it will), let’s merge this and I’ll build a PR

## Screenshots

This is what I see in the terminal for [this contrived Tugboat preview](https://dashboard.tugboat.qa/61798da78c559d0c0820775e):

![image](https://user-images.githubusercontent.com/439649/139145824-86749402-ce36-4dad-8bdf-4a6831c1ec17.png)

## Documentation

n/a