### PR TITLE
GH-3059 Install libx11-xcb1 package in node service

### DIFF
--- a/services/node/Dockerfile
+++ b/services/node/Dockerfile
@@ -7,6 +7,7 @@ RUN curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add - \
     && apt-get --quiet install -y --no-install-recommends \
       libxss1 \
       libxtst6 \
+      libx11-xcb1 \
       google-chrome-stable \
       nodejs \
       yarn \


### PR DESCRIPTION
## Description

This PR adds the `libx11-xcb1` package to the `node` image.

## Motivation / Context

Our `integration-tests` service in `benz-platform` started failing
with Puppeteer throwing an exception about this missing library.

Related to chromatichq/benz-tickets#3059.

## Testing Instructions / How This Has Been Tested

I have validated this change by installing `libx11-xcb1` manually on a Tugboat preview’s `integration-tests` service and re-running tests. I then created ChromaticHQ/benz-platform#4458 to install the package in the `build` step. The preview for it [built successfully](https://dashboard.tugboatqa.com/63b5d624e6bc62df9c72c956) and tests actually run now (failing [for reasons _other than_](https://pr4458-ti0ak887kktpextjwrcxvdgoorfxvsot.tugboatqa.com/test-results.txt) this missing package).

## Screenshots

n/a

## Documentation

n/a