### PR TITLE
Install Node using n and Yarn using npm in node image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,11 @@
 # Chromatic Docker Images
 
-Custom docker images, published to
-[DockerHub](https://hub.docker.com/u/chromatichq/).
+Custom docker images, published to [DockerHub](https://hub.docker.com/u/chromatichq/).
 
-These images are rebuilt weekly on Thursday nights so if any issues are
-introduced from upstream changes we have the opportunity to resolve them before
-the weekend.
+These images are rebuilt weekly on Thursday nights so if any issues are introduced from upstream changes we have the opportunity to resolve them before the weekend.
 
-## A note on `php-apache-node`
+## A note on how Node is installed
 
-The `php-apache-node` image installs [n](https://github.com/tj/n) and installs
-[Node LTS](https://nodejs.org/en/about/releases/) by default. Any projects
-using this image may invoke `n auto` to install whatever version of Node.js is
-specified in the project’s `.nvmrc`. Other filenames are also supported; see
-[Specifying Node.js Versions](https://github.com/tj/n#specifying-nodejs-versions)
-for further details.
+The `node` and `php-apache-node` images use [n](https://github.com/tj/n) to install [Node LTS](https://nodejs.org/en/about/releases/) by default. Any projects using these images may invoke `n auto` to install whatever version of Node.js is specified in the project’s `.node-version`. Other filenames are also supported; see [Specifying Node.js Versions](https://github.com/tj/n#specifying-nodejs-versions) for further details.
 
-The image also pre-installs Yarn, so any `yarn *` commands also work out of the
-box.
+The image also pre-installs Yarn so that any `yarn *` commands also work out of the box and `http-server` to easily serve static files when necessary.

--- a/services/node/Dockerfile
+++ b/services/node/Dockerfile
@@ -2,7 +2,7 @@ FROM tugboatqa/node:latest
 RUN git clone https://github.com/tj/n.git \
     && cd n && make install && cd .. \
     && n lts \
-    && yarn global install http-server \
+    && yarn global add http-server \
     && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
     && echo "deb http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google.list \
     && apt-get update \

--- a/services/node/Dockerfile
+++ b/services/node/Dockerfile
@@ -2,7 +2,6 @@ FROM tugboatqa/node:latest
 RUN git clone https://github.com/tj/n.git \
     && cd n && make install && cd .. \
     && n lts \
-    && npm install --global yarn \
     && yarn global install http-server \
     && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
     && echo "deb http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google.list \

--- a/services/node/Dockerfile
+++ b/services/node/Dockerfile
@@ -1,6 +1,9 @@
-FROM tugboatqa/node:14
-RUN curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add - \
-    && echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list \
+FROM tugboatqa/node:latest
+RUN git clone https://github.com/tj/n.git \
+    && cd n && make install && cd .. \
+    && n lts \
+    && npm install --global yarn \
+    && yarn global install http-server \
     && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
     && echo "deb http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google.list \
     && apt-get update \
@@ -9,7 +12,5 @@ RUN curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add - \
       libxtst6 \
       libx11-xcb1 \
       google-chrome-stable \
-      nodejs \
-      yarn \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/services/php-apache-node/Dockerfile
+++ b/services/php-apache-node/Dockerfile
@@ -3,7 +3,7 @@ FROM tugboatqa/php:${PHP_VERSION}-apache
 ENV COMPOSER_DISCARD_CHANGES=true
 ENV COMPOSER_NO_INTERACTION=true
 ENV COMPOSER_ALLOW_SUPERUSER=true
-RUN git clone --branch v8.0.1 https://github.com/tj/n.git \
+RUN git clone https://github.com/tj/n.git \
     && cd n && make install && cd .. \
     && n lts \
     && npm install --global yarn \


### PR DESCRIPTION
## Description

This PR updates our `node` image to:

- Use Tugboat’s `node:latest` instead of a specific version of Node.
- Install the LTS version of Node using `n`.<sup>†</sup>
- Install Yarn using `npm` right after installing Node with `n`.<sup>†</sup>

It also updates the `php-apache-node` image to always use the latest version of `n`, instead of pointing to a specific branch.

---

<sup>†</sup> These updates are tried and true, as they have powered how we install both Node and Yarn in our `php-apache-node` image for a very long time. See #22 for details and background.

## Motivation / Context

I am [updating `benz-platform`](https://github.com/ChromaticHQ/benz-platform/pull/4935) to use Node v20 (latest version) and would like to use `n` to install the version of Node declared in the project’s `.node-version` using `n` in the `integration-tests` service for Tugboat.

## Testing Instructions / How This Has Been Tested

1. Merge this PR.
2. Trigger a rebuild of our images.
3. Rebuild the Tugboat preview for the `benz-platform` PR linked above.
4. Confirm that it all images build successfully.

## Screenshots

n/a

## Documentation

I updated the README.