### PR TITLE
GH-52 Report build failures to #devops-alerts in Slack

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -52,7 +52,7 @@ jobs:
           tags: chromatichq/${{ matrix.service }}:${{ matrix.php }}
 
       - name: Notify slack on failure
-        if: failure() && github.event_name != 'pull_request'
+        if: ${{ failure() && (github.event_name == 'push' || github.event_name == 'schedule') }}
         uses: voxmedia/github-action-slack-notify-build@v2
         with:
           channel: devops-alerts
@@ -92,7 +92,7 @@ jobs:
           tags: chromatichq/${{ matrix.service }}:latest
 
       - name: Notify slack on failure
-        if: failure() && github.event_name != 'pull_request'
+        if: ${{ failure() && (github.event_name == 'push' || github.event_name == 'schedule') }}
         uses: voxmedia/github-action-slack-notify-build@v2
         with:
           channel: devops-alerts

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -52,7 +52,7 @@ jobs:
           tags: chromatichq/${{ matrix.service }}:${{ matrix.php }}
 
       - name: Notify slack on failure
-        if: failure()
+        if: failure() && github.event_name != 'pull_request'
         uses: voxmedia/github-action-slack-notify-build@v2
         with:
           channel: devops-alerts
@@ -92,7 +92,7 @@ jobs:
           tags: chromatichq/${{ matrix.service }}:latest
 
       - name: Notify slack on failure
-        if: failure()
+        if: failure() && github.event_name != 'pull_request'
         uses: voxmedia/github-action-slack-notify-build@v2
         with:
           channel: devops-alerts

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -51,6 +51,16 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: chromatichq/${{ matrix.service }}:${{ matrix.php }}
 
+      - name: Notify slack on failure
+        if: failure()
+        uses: voxmedia/github-action-slack-notify-build@v2
+        with:
+          channel: devops-alerts
+          status: FAILED
+          color: danger
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.GHACTION_SLACK_BOT_TOKEN }}
+
   image-build:
     runs-on: ubuntu-latest
     strategy:
@@ -80,3 +90,13 @@ jobs:
           file: services/${{ matrix.service }}/Dockerfile
           push: ${{ github.event_name != 'pull_request' }}
           tags: chromatichq/${{ matrix.service }}:latest
+
+      - name: Notify slack on failure
+        if: failure()
+        uses: voxmedia/github-action-slack-notify-build@v2
+        with:
+          channel: devops-alerts
+          status: FAILED
+          color: danger
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.GHACTION_SLACK_BOT_TOKEN }}


### PR DESCRIPTION
## Description

This PR adds a step to each of our image building jobs that reports failures to our `#devops-alerts` channel in Slack. The step is configured to only report failures on builds _not_ triggered by a pull request.

## Motivation / Context

Closes #52.

## Testing Instructions / How This Has Been Tested

If there are failures with the build in this PR, we should see it reported in Slack.

## Screenshots

The idea is for build failures to be reported when they occur _outside_ of a pull request, but to test this PR, I left that condition out and here is the message posted in Slack, reporting failures not related to this PR, which we’re currently seeing in `main`:
<img width="642" alt="image" src="https://github.com/ChromaticHQ/docker-images/assets/439649/dabf8b18-99e4-4545-96e5-d9e7d753d220">

After updating the step to limit failure reports to non-PR builds, here’s the step being skipped:
<img width="236" alt="image" src="https://github.com/ChromaticHQ/docker-images/assets/439649/4877f1ae-ad0a-4435-b7b4-36b42104a7e6">

## Documentation

n/a