### PR TITLE
Remove opcache install as it is now included in the upstream image.

### DIFF
--- a/services/php-apache-node/Dockerfile
+++ b/services/php-apache-node/Dockerfile
@@ -16,8 +16,6 @@ RUN git clone https://github.com/tj/n.git \
       software-properties-common \
     && yes '' | pecl install -fo redis \
     && rm -rf /tmp/pear \
-    && docker-php-ext-install opcache \
-    && docker-php-ext-enable opcache \
     && docker-php-ext-enable redis \
     && docker-php-ext-install zip \
     && a2enmod headers rewrite \


### PR DESCRIPTION
## Description
Remove opcache install as it is now included in the upstream image.

## Motivation / Context
https://github.com/TugboatQA/images/pull/125

## Testing Instructions / How This Has Been Tested
TBD