### PR TITLE
Update slack-notify action to use v1.6.0 tag

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Notify slack on failure
         if: ${{ failure() && (github.event_name == 'push' || github.event_name == 'schedule') }}
-        uses: voxmedia/github-action-slack-notify-build@v2
+        uses: voxmedia/github-action-slack-notify-build@v1.6.0
         with:
           channel: devops-alerts
           status: FAILED
@@ -93,7 +93,7 @@ jobs:
 
       - name: Notify slack on failure
         if: ${{ failure() && (github.event_name == 'push' || github.event_name == 'schedule') }}
-        uses: voxmedia/github-action-slack-notify-build@v2
+        uses: voxmedia/github-action-slack-notify-build@v1.6.0
         with:
           channel: devops-alerts
           status: FAILED


### PR DESCRIPTION
## Description
Update slack-notify action to use v1.6.0 tag.

## Motivation / Context
[v2 tag is not valid](https://github.com/voxmedia/github-action-slack-notify-build/issues/49). Development has continued on the 1.x branch.

## Testing Instructions / How This Has Been Tested
N/A