### PR TITLE
Add PHP 8.3 support

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         service: ["php-apache-node"]
-        php: [7.4, 8.0, 8.1, 8.2]
+        php: [7.4, 8.0, 8.1, 8.2, 8.3]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4.1.1


### PR DESCRIPTION
## Description
Add PHP 8.3 support

## Motivation / Context
https://thephp.foundation/blog/2023/11/23/php-83/

## Testing Instructions / How This Has Been Tested
Tests should pass.