### PR TITLE
Deprecate PHP 7.4 and 8.0.

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -22,13 +22,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        service: ["php-apache-node", "php-nginx-fpm"]
-        php: [7.4, 8.0, 8.1, 8.2, 8.3]
-        exclude:
-          - service: php-nginx-fpm
-            php: 7.4
-          - service: php-nginx-fpm
-            php: 8.0
+        service:
+          - php-apache-node
+          - php-nginx-fpm
+        php:
+          - 8.1
+          - 8.2
+          - 8.3
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Description
Deprecate PHP 7.4 and 8.0.

## Motivation / Context
Closes #72 

## Testing Instructions / How This Has Been Tested
- I reviewed all of our repos that use these images and identified none that are still relying on PHP 7.4 or 8.0.
- Tests are passing.