### PR TITLE
Add solr image with cloud mode for tugboat.

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -71,7 +71,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        service: [node]
+        service:
+          - node
+          - solr
     steps:
       - name: Checkout code
         uses: actions/checkout@v4.1.1

--- a/services/solr/Dockerfile
+++ b/services/solr/Dockerfile
@@ -61,4 +61,5 @@ solr zk cp file:/var/solr/data/security.json zk:/security.json -z localhost:9983
 EOF
 
 RUN chown -R solr:solr /var/solr/data && \
-chmod +x docker/scripts/zkauth.sh
+chmod +x docker/scripts/zkauth.sh && \
+sed -i '/<!-- Uncomment to enable handling of X-Forwarded- style headers/,/-->/c\    <Call name="addCustomizer"><Arg><New class="org.eclipse.jetty.server.ForwardedRequestCustomizer"/></Arg></Call>' /opt/solr/server/etc/jetty.xml

--- a/services/solr/Dockerfile
+++ b/services/solr/Dockerfile
@@ -1,0 +1,64 @@
+ARG SOLR_VERSION=9.6
+FROM tugboatqa/solr:${SOLR_VERSION}
+ENV COMPOSER_DISCARD_CHANGES=true
+ENV COMPOSER_NO_INTERACTION=true
+ENV COMPOSER_ALLOW_SUPERUSER=true
+
+ENV SOLR_OPTS="-Djute.maxbuffer=50000000"
+ENV SOLR_AUTH_TYPE=basic
+ENV SOLR_AUTHENTICATION_OPTS="-Dbasicauth=solr:SolrRocks"
+ENV SOLR_MODE=solrcloud
+
+COPY <<EOF /etc/default/solr.in.sh
+SOLR_OPTS="-Djute.maxbuffer=50000000"
+SOLR_AUTH_TYPE=basic
+SOLR_AUTHENTICATION_OPTS="-Dbasicauth=solr:SolrRocks"
+SOLR_MODE=solrcloud
+EOF
+
+COPY <<EOF /var/solr/data/security.json
+{
+  "#ddev-generated":true,
+  "authentication":{
+    "class":"solr.BasicAuthPlugin",
+    "credentials":{
+      "solr":"IV0EHq1OnNrj6gvRCwvFwTrZ1+z1oBbnQdiVC3otuq0= Ndd7LKvVBAaZIF0QAVi1ekCfAJXr1GGfLtRUXhgrF8c="
+    },
+    "blockUnknown":false
+  },
+  "authorization":{
+    "class":"solr.RuleBasedAuthorizationPlugin",
+    "permissions":[
+      {
+        "name":"admin-ui",
+        "path":"/admin/*",
+        "role":"admin"
+      },
+      {
+        "name":"read",
+        "role":null
+      },
+      {
+        "name":"update",
+        "role":null
+      },
+      {
+        "name":"all",
+        "role":"admin"
+      }
+    ],
+    "user-role":{
+      "solr":"admin"
+    }
+  }
+}
+EOF
+
+COPY <<EOF docker/scripts/zkauth.sh
+#!/bin/sh
+echo "set zoo keeper auth"
+solr zk cp file:/var/solr/data/security.json zk:/security.json -z localhost:9983
+EOF
+
+RUN chown -R solr:solr /var/solr/data && \
+chmod +x docker/scripts/zkauth.sh


### PR DESCRIPTION
## Description
This sets up a docker container that enables solrcloud mode for use in Tugboat. 

To use this be sure to either:

Run `solr zk cp file:/var/solr/data/security.json zk:/security.json -z localhost:9983` in the init phase of the service, or
Run `/opt/solr/docker/scripts/zkauth.sh`

## Motivation / Context
The default TugboatQA docker image does not support solrcloud mode, and, once the container is running, it's very hard to configure it for solrcloud mode while still keeping intact the service monitoring and service invocations that are the preferred way for Tugboat to work. 

## Testing Instructions / How This Has Been Tested
```
cd services/solr && docker build -t solrcloud .
docker run solrcloud
docker exec -it <imageid> bash
/opt/solr/docker/scripts/zkauth.sh
```

## Screenshots
<!-- Would including screenshots be helpful to the reviewer? -->

## Documentation
<!-- Do any of the changes warrant documentation updates? -->
