### PR TITLE
Remove deprecated apt-key command

### DIFF
--- a/services/node/Dockerfile
+++ b/services/node/Dockerfile
@@ -3,8 +3,8 @@ RUN git clone https://github.com/tj/n.git \
     && cd n && make install && cd .. \
     && n lts \
     && yarn global add http-server \
-    && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
-    && echo "deb http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google.list \
+    && wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | gpg --dearmor -o /usr/share/keyrings/google-chrome.gpg \
+    && echo "deb [arch=amd64 signed-by=/usr/share/keyrings/google-chrome.gpg] http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google-chrome.list \
     && apt-get update \
     && apt-get --quiet install -y --no-install-recommends \
       libxss1 \

--- a/services/php-apache-node/Dockerfile
+++ b/services/php-apache-node/Dockerfile
@@ -7,8 +7,8 @@ RUN git clone https://github.com/tj/n.git \
     && cd n && make install && cd .. \
     && n lts \
     && npm install --global yarn \
-    && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
-    && echo "deb http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google.list \
+    && wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | gpg --dearmor -o /usr/share/keyrings/google-chrome.gpg \
+    && echo "deb [arch=amd64 signed-by=/usr/share/keyrings/google-chrome.gpg] http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google-chrome.list \
     && apt-get update \
     && apt-get --quiet install -y --no-install-recommends \
       libzip-dev \

--- a/services/php-apache-node/Dockerfile
+++ b/services/php-apache-node/Dockerfile
@@ -13,7 +13,6 @@ RUN git clone https://github.com/tj/n.git \
     && apt-get --quiet install -y --no-install-recommends \
       libzip-dev \
       redis-tools \
-      software-properties-common \
     && yes '' | pecl install -fo redis \
     && rm -rf /tmp/pear \
     && docker-php-ext-enable redis \

--- a/services/php-nginx-fpm/Dockerfile
+++ b/services/php-nginx-fpm/Dockerfile
@@ -7,8 +7,8 @@ RUN git clone https://github.com/tj/n.git \
     && cd n && make install && cd .. \
     && n lts \
     && npm install --global yarn \
-    && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
-    && echo "deb http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google.list \
+    && wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | gpg --dearmor -o /usr/share/keyrings/google-chrome.gpg \
+    && echo "deb [arch=amd64 signed-by=/usr/share/keyrings/google-chrome.gpg] http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google-chrome.list \
     && apt-get update \
     && apt-get --quiet install -y --no-install-recommends \
       libzip-dev \

--- a/services/php-nginx-fpm/Dockerfile
+++ b/services/php-nginx-fpm/Dockerfile
@@ -13,7 +13,6 @@ RUN git clone https://github.com/tj/n.git \
     && apt-get --quiet install -y --no-install-recommends \
       libzip-dev \
       redis-tools \
-      software-properties-common \
     && yes '' | pecl install -fo redis \
     && rm -rf /tmp/pear \
     && docker-php-ext-enable redis \


### PR DESCRIPTION
## Description
I noticed that Tugboat previews are failing, reporting:

```
Err:5 http://dl.google.com/linux/chrome/deb stable InRelease
  The following signatures couldn't be verified because the public key is not available: NO_PUBKEY FD533C07C264648F
Reading package lists...
W: GPG error: http://dl.google.com/linux/chrome/deb stable InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY FD533C07C264648F
E: The repository 'http://dl.google.com/linux/chrome/deb stable InRelease' is not signed.
2026-02-13T12:54:48.667Z - Command Failed (Tugboat Error 1064): Exit code: 100; Command: apt-get update
```
Apparently this is failing all over the internet because Google has swapped out its keys and now we need to alter the commands that accept them.

## Motivation / Context
Broken Tugboat builds.

## Testing Instructions / How This Has Been Tested
If this gets approved we can merge, get this update pushed to Docker and our Tugboat previews should build.