### PR TITLE
Add yarn installation to Dockerfile

### DIFF
--- a/services/node/Dockerfile
+++ b/services/node/Dockerfile
@@ -2,6 +2,7 @@ FROM tugboatqa/node:latest
 RUN git clone https://github.com/tj/n.git \
     && cd n && make install && cd .. \
     && n lts \
+    && npm install -g yarn \
     && yarn global add http-server \
     && wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | gpg --dearmor -o /usr/share/keyrings/google-chrome.gpg \
     && echo "deb [arch=amd64 signed-by=/usr/share/keyrings/google-chrome.gpg] http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google-chrome.list \


### PR DESCRIPTION
## Description
This PR updates the Dockerfile for node. The weekly build failed, but it turns out they have been failing for a month. It looks like Tugboat switched to a base image with node 26, that no longer pre-installs yarn.

Recent failed run: https://github.com/ChromaticHQ/docker-images/actions/runs/26979354440

### Gemini description
>Why it permanently broke after May
>When Tugboat updated the base stack to Debian 13 (Trixie), Yarn was completely removed from the OS configuration layers because Classic Yarn v1 has been officially deprecated.
>
>As a result, the only way Yarn can exist inside the new container is if it is bundled natively within the active Node runtime binary distribution. But as we uncovered from the Node release schedule, the modern Node versions unbundled Yarn completely in favor of Corepack.
>
>So when your script hits n lts on the new image:
>
>1. It swaps your system to a fresh Node LTS profile.
>
>2. The operating system has no native yarn fallback command.
>
>3. The new Node LTS version has no pre-bundled yarn binary.
>
>4. yarn global add crashes immediately with exit code 127.
>
>The Solution
>We explicitly install yarn globally via npm immediately after the n lts command switches the Node environment. This ensures yarn is always present on the execution path, decoupling our build success from upstream base-image changes.
>
>Conclusion
>The fix (npm install -g yarn) is absolutely the right remedy here. By explicitly installing it via npm after your n lts step, you insulated your pipeline from Node 26's upstream decision to unbundle Yarn.

## Motivation / Context
Failing builds.

## Consider?
Instead of `tugboatqa/node:latest`, use a specific node version so upstream changes for `latest` don't surprise us? The downside is we'll find out in a year or two we're X versions behind. :)